### PR TITLE
Adapt doclet to JDK 17

### DIFF
--- a/src/jdiff/APIDiff.java
+++ b/src/jdiff/APIDiff.java
@@ -1,7 +1,6 @@
 package jdiff;
 
 import java.util.*;
-import com.sun.javadoc.*;
 
 /**
  * The class contains the changes between two API objects; packages added,

--- a/src/jdiff/ClassDiff.java
+++ b/src/jdiff/ClassDiff.java
@@ -1,7 +1,6 @@
 package jdiff;
 
 import java.util.*;
-import com.sun.javadoc.*;
 
 /**
  * The changes between two classes.

--- a/src/jdiff/MemberDiff.java
+++ b/src/jdiff/MemberDiff.java
@@ -1,7 +1,6 @@
 package jdiff;
 
 import java.util.*;
-import com.sun.javadoc.*;
 
 /**
  * The changes between two class constructor, method or field members.

--- a/src/jdiff/PackageDiff.java
+++ b/src/jdiff/PackageDiff.java
@@ -1,7 +1,6 @@
 package jdiff;
 
 import java.util.*;
-import com.sun.javadoc.*;
 
 /**
  * Changes between two packages.

--- a/src/jdiff/doc/BaseDoc.java
+++ b/src/jdiff/doc/BaseDoc.java
@@ -1,0 +1,112 @@
+package jdiff.doc;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.lang.model.element.Element;
+
+/**
+ * Common functionality for {@link Doc} implementations.
+ */
+abstract class BaseDoc implements Doc {
+    private final DocEnvironment environment;
+    private final Element element;
+    private final String overrideName;
+
+    private Map<String, List<Tag>> tagsByName;
+    private List<Tag> allTags;
+
+    BaseDoc(DocEnvironment environment, Element element, String overrideName) {
+        this.environment = environment;
+        this.element = element;
+        this.overrideName = overrideName;
+    }
+
+    Element element() {
+        return element;
+    }
+
+    DocEnvironment environment() {
+        return environment;
+    }
+
+    @Override
+    public String name() {
+        if (overrideName != null) {
+            return overrideName;
+        }
+        if (element == null) {
+            return "";
+        }
+        return element.getSimpleName().toString();
+    }
+
+    @Override
+    public String getRawCommentText() {
+        return environment.docComment(element);
+    }
+
+    @Override
+    public Tag[] tags() {
+        ensureTagsParsed();
+        if (allTags.isEmpty()) {
+            return new Tag[0];
+        }
+        return allTags.toArray(new Tag[0]);
+    }
+
+    @Override
+    public Tag[] tags(String name) {
+        ensureTagsParsed();
+        List<Tag> tags = tagsByName.get(name);
+        if (tags == null || tags.isEmpty()) {
+            return new Tag[0];
+        }
+        return tags.toArray(new Tag[0]);
+    }
+
+    private void ensureTagsParsed() {
+        if (tagsByName != null) {
+            return;
+        }
+        tagsByName = new HashMap<>();
+        allTags = new ArrayList<>();
+        String raw = getRawCommentText();
+        if (raw == null) {
+            return;
+        }
+        String currentName = null;
+        StringBuilder currentText = null;
+        for (String line : raw.split("\\r?\\n")) {
+            String trimmed = line.trim();
+            if (trimmed.startsWith("@")) {
+                if (currentName != null) {
+                    addTag(currentName, currentText.toString());
+                }
+                int space = trimmed.indexOf(' ');
+                if (space == -1) {
+                    currentName = trimmed.substring(1);
+                    currentText = new StringBuilder();
+                } else {
+                    currentName = trimmed.substring(1, space);
+                    currentText = new StringBuilder(trimmed.substring(space + 1).trim());
+                }
+            } else if (currentName != null) {
+                if (currentText.length() != 0) {
+                    currentText.append('\n');
+                }
+                currentText.append(trimmed);
+            }
+        }
+        if (currentName != null) {
+            addTag(currentName, currentText.toString());
+        }
+    }
+
+    private void addTag(String name, String text) {
+        Tag tag = new TagImpl(name, text);
+        allTags.add(tag);
+        tagsByName.computeIfAbsent(name, key -> new ArrayList<>()).add(tag);
+    }
+}

--- a/src/jdiff/doc/BaseProgramElementDoc.java
+++ b/src/jdiff/doc/BaseProgramElementDoc.java
@@ -1,0 +1,47 @@
+package jdiff.doc;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.Modifier;
+
+abstract class BaseProgramElementDoc extends BaseDoc implements ProgramElementDoc {
+    private final Element element;
+
+    BaseProgramElementDoc(DocEnvironment environment, Element element) {
+        super(environment, element, null);
+        this.element = element;
+    }
+
+    Element asElement() {
+        return element;
+    }
+
+    @Override
+    public boolean isStatic() {
+        return element.getModifiers().contains(Modifier.STATIC);
+    }
+
+    @Override
+    public boolean isFinal() {
+        return element.getModifiers().contains(Modifier.FINAL);
+    }
+
+    @Override
+    public boolean isPublic() {
+        return element.getModifiers().contains(Modifier.PUBLIC);
+    }
+
+    @Override
+    public boolean isProtected() {
+        return element.getModifiers().contains(Modifier.PROTECTED);
+    }
+
+    @Override
+    public boolean isPrivate() {
+        return element.getModifiers().contains(Modifier.PRIVATE);
+    }
+
+    @Override
+    public boolean isPackagePrivate() {
+        return !(isPublic() || isProtected() || isPrivate());
+    }
+}

--- a/src/jdiff/doc/ClassDoc.java
+++ b/src/jdiff/doc/ClassDoc.java
@@ -1,0 +1,29 @@
+package jdiff.doc;
+
+/**
+ * Represents documentation for a class, interface, enum or record.
+ */
+public interface ClassDoc extends ProgramElementDoc, Type, Comparable<ClassDoc> {
+    /**
+     * Returns the simple name of the class.
+     */
+    String name();
+
+    boolean isInterface();
+
+    boolean isAbstract();
+
+    PackageDoc containingPackage();
+
+    Type superclassType();
+
+    Type[] interfaceTypes();
+
+    ConstructorDoc[] constructors();
+
+    MethodDoc[] methods();
+
+    FieldDoc[] fields();
+
+    ClassDoc[] innerClasses();
+}

--- a/src/jdiff/doc/ClassDocImpl.java
+++ b/src/jdiff/doc/ClassDocImpl.java
@@ -1,0 +1,140 @@
+package jdiff.doc;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
+
+final class ClassDocImpl extends BaseProgramElementDoc implements ClassDoc {
+    private final DocEnvironment environment;
+    private final TypeElement element;
+    private final PackageDocImpl packageDoc;
+
+    private ConstructorDoc[] constructors;
+    private MethodDoc[] methods;
+    private FieldDoc[] fields;
+    private Type[] interfaces;
+    private ClassDoc[] innerClasses;
+
+    ClassDocImpl(DocEnvironment environment, TypeElement element, PackageDocImpl packageDoc) {
+        super(environment, element);
+        this.environment = environment;
+        this.element = element;
+        this.packageDoc = packageDoc;
+    }
+
+    @Override
+    public String name() {
+        return element.getSimpleName().toString();
+    }
+
+    @Override
+    public String qualifiedTypeName() {
+        return element.getQualifiedName().toString();
+    }
+
+    @Override
+    public String toString() {
+        return qualifiedTypeName();
+    }
+
+    @Override
+    public boolean isInterface() {
+        ElementKind kind = element.getKind();
+        return kind == ElementKind.INTERFACE || kind == ElementKind.ANNOTATION_TYPE;
+    }
+
+    @Override
+    public boolean isAbstract() {
+        return element.getModifiers().contains(Modifier.ABSTRACT) || isInterface();
+    }
+
+    @Override
+    public PackageDoc containingPackage() {
+        return packageDoc;
+    }
+
+    @Override
+    public Type superclassType() {
+        TypeMirror mirror = element.getSuperclass();
+        if (mirror == null) {
+            return null;
+        }
+        return environment.getType(mirror);
+    }
+
+    @Override
+    public Type[] interfaceTypes() {
+        if (interfaces == null) {
+            interfaces = environment.getTypes(new ArrayList<>(element.getInterfaces()));
+        }
+        return interfaces;
+    }
+
+    @Override
+    public ConstructorDoc[] constructors() {
+        if (constructors == null) {
+            List<ConstructorDoc> list = new ArrayList<>();
+            for (Element e : element.getEnclosedElements()) {
+                if (e.getKind() == ElementKind.CONSTRUCTOR) {
+                    list.add(new ConstructorDocImpl(environment, (ExecutableElement) e, this));
+                }
+            }
+            constructors = list.toArray(new ConstructorDoc[0]);
+        }
+        return constructors;
+    }
+
+    @Override
+    public MethodDoc[] methods() {
+        if (methods == null) {
+            List<MethodDoc> list = new ArrayList<>();
+            for (Element e : element.getEnclosedElements()) {
+                if (e.getKind() == ElementKind.METHOD) {
+                    list.add(new MethodDocImpl(environment, (ExecutableElement) e));
+                }
+            }
+            methods = list.toArray(new MethodDoc[0]);
+        }
+        return methods;
+    }
+
+    @Override
+    public FieldDoc[] fields() {
+        if (fields == null) {
+            List<FieldDoc> list = new ArrayList<>();
+            for (Element e : element.getEnclosedElements()) {
+                if (e.getKind() == ElementKind.FIELD) {
+                    list.add(new FieldDocImpl(environment, e));
+                }
+            }
+            fields = list.toArray(new FieldDoc[0]);
+        }
+        return fields;
+    }
+
+    @Override
+    public ClassDoc[] innerClasses() {
+        if (innerClasses == null) {
+            List<ClassDoc> list = new ArrayList<>();
+            for (Element e : element.getEnclosedElements()) {
+                if (e.getKind().isClass() || e.getKind().isInterface()) {
+                    if (e instanceof TypeElement) {
+                        list.add(environment.getClassDoc((TypeElement) e));
+                    }
+                }
+            }
+            innerClasses = list.toArray(new ClassDoc[0]);
+        }
+        return innerClasses;
+    }
+
+    @Override
+    public int compareTo(ClassDoc other) {
+        return this.qualifiedTypeName().compareTo(other.qualifiedTypeName());
+    }
+}

--- a/src/jdiff/doc/ConstructorDoc.java
+++ b/src/jdiff/doc/ConstructorDoc.java
@@ -1,0 +1,9 @@
+package jdiff.doc;
+
+public interface ConstructorDoc extends ProgramElementDoc {
+    String name();
+
+    Parameter[] parameters();
+
+    Type[] thrownExceptions();
+}

--- a/src/jdiff/doc/ConstructorDocImpl.java
+++ b/src/jdiff/doc/ConstructorDocImpl.java
@@ -1,0 +1,27 @@
+package jdiff.doc;
+
+import javax.lang.model.element.ExecutableElement;
+
+final class ConstructorDocImpl extends ExecutableMemberDocImpl implements ConstructorDoc {
+    private final ClassDocImpl owner;
+
+    ConstructorDocImpl(DocEnvironment environment, ExecutableElement element, ClassDocImpl owner) {
+        super(environment, element);
+        this.owner = owner;
+    }
+
+    @Override
+    public Parameter[] parameters() {
+        return super.parameters();
+    }
+
+    @Override
+    public Type[] thrownExceptions() {
+        return super.thrownExceptions();
+    }
+
+    @Override
+    public String name() {
+        return owner.name();
+    }
+}

--- a/src/jdiff/doc/Doc.java
+++ b/src/jdiff/doc/Doc.java
@@ -1,0 +1,26 @@
+package jdiff.doc;
+
+/**
+ * Minimal view of a documented element.
+ */
+public interface Doc {
+    /**
+     * Returns the name of the documented element.
+     */
+    String name();
+
+    /**
+     * Returns the raw documentation comment text, or {@code null} if none.
+     */
+    String getRawCommentText();
+
+    /**
+     * Returns all block tags on this element.
+     */
+    Tag[] tags();
+
+    /**
+     * Returns the block tags matching the provided name (without the leading '@').
+     */
+    Tag[] tags(String name);
+}

--- a/src/jdiff/doc/DocEnvironment.java
+++ b/src/jdiff/doc/DocEnvironment.java
@@ -1,0 +1,124 @@
+package jdiff.doc;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Elements;
+import javax.lang.model.util.Types;
+import jdk.javadoc.doclet.DocletEnvironment;
+
+/**
+ * Shared state used when adapting {@link DocletEnvironment} to the doclet model used by JDiff.
+ */
+class DocEnvironment {
+    private final DocletEnvironment environment;
+    private final Elements elements;
+    private final Types types;
+
+    private final Map<PackageElement, PackageDocImpl> packageByElement = new LinkedHashMap<>();
+    private final Map<String, PackageDocImpl> packageByName = new LinkedHashMap<>();
+    private final Map<TypeElement, ClassDocImpl> classByElement = new LinkedHashMap<>();
+    private final Map<TypeMirror, TypeImpl> typeCache = new IdentityHashMap<>();
+
+    private final PackageDocImpl anonymousPackage;
+
+    DocEnvironment(DocletEnvironment environment) {
+        this.environment = environment;
+        this.elements = environment.getElementUtils();
+        this.types = environment.getTypeUtils();
+        this.anonymousPackage = new PackageDocImpl(this, null, "anonymous");
+        packageByName.put(this.anonymousPackage.name(), this.anonymousPackage);
+    }
+
+    DocletEnvironment environment() {
+        return environment;
+    }
+
+    Elements elements() {
+        return elements;
+    }
+
+    Types types() {
+        return types;
+    }
+
+    PackageDocImpl getPackage(PackageElement element) {
+        if (element == null || element.isUnnamed()) {
+            return anonymousPackage;
+        }
+        return packageByElement.computeIfAbsent(element, pkg -> {
+            String name = pkg.getQualifiedName().toString();
+            PackageDocImpl doc = new PackageDocImpl(this, pkg, name);
+            packageByName.put(name, doc);
+            return doc;
+        });
+    }
+
+    PackageDocImpl getOrCreatePackageByName(String name) {
+        if (name == null) {
+            return anonymousPackage;
+        }
+        return packageByName.computeIfAbsent(name, key -> new PackageDocImpl(this, null, key));
+    }
+
+    ClassDocImpl getClassDoc(TypeElement element) {
+        return classByElement.computeIfAbsent(element, type -> {
+            PackageDocImpl pkg = getPackage(elements.getPackageOf(type));
+            ClassDocImpl doc = new ClassDocImpl(this, type, pkg);
+            pkg.addClass(doc);
+            return doc;
+        });
+    }
+
+    Collection<PackageDocImpl> packages() {
+        return Collections.unmodifiableCollection(packageByName.values());
+    }
+
+    Type getType(TypeMirror mirror) {
+        if (mirror == null) {
+            return null;
+        }
+        if (mirror.getKind() == TypeKind.NONE) {
+            return null;
+        }
+        return typeCache.computeIfAbsent(mirror, m -> new TypeImpl(this, m));
+    }
+
+    Type[] getTypes(List<? extends TypeMirror> mirrors) {
+        if (mirrors.isEmpty()) {
+            return new Type[0];
+        }
+        List<Type> result = new ArrayList<>(mirrors.size());
+        for (TypeMirror mirror : mirrors) {
+            Type type = getType(mirror);
+            if (type != null) {
+                result.add(type);
+            }
+        }
+        return result.toArray(new Type[0]);
+    }
+
+    String docComment(Element element) {
+        if (element == null) {
+            return null;
+        }
+        return elements.getDocComment(element);
+    }
+
+    PackageDocImpl anonymousPackage() {
+        return anonymousPackage;
+    }
+
+    void registerSyntheticPackage(PackageDocImpl pkg) {
+        packageByName.put(pkg.name(), pkg);
+    }
+}

--- a/src/jdiff/doc/ExecutableMemberDocImpl.java
+++ b/src/jdiff/doc/ExecutableMemberDocImpl.java
@@ -1,0 +1,51 @@
+package jdiff.doc;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.VariableElement;
+
+abstract class ExecutableMemberDocImpl extends BaseProgramElementDoc {
+    private final DocEnvironment environment;
+    private final ExecutableElement element;
+
+    private Parameter[] parameters;
+    private Type[] thrownExceptions;
+
+    ExecutableMemberDocImpl(DocEnvironment environment, ExecutableElement element) {
+        super(environment, element);
+        this.environment = environment;
+        this.element = element;
+    }
+
+    ExecutableElement executableElement() {
+        return element;
+    }
+
+    DocEnvironment environment() {
+        return environment;
+    }
+
+    @Override
+    public String name() {
+        return element.getSimpleName().toString();
+    }
+
+    public Parameter[] parameters() {
+        if (parameters == null) {
+            List<Parameter> list = new ArrayList<>();
+            for (VariableElement param : element.getParameters()) {
+                list.add(new ParameterImpl(environment, param));
+            }
+            parameters = list.toArray(new Parameter[0]);
+        }
+        return parameters;
+    }
+
+    public Type[] thrownExceptions() {
+        if (thrownExceptions == null) {
+            thrownExceptions = environment.getTypes(element.getThrownTypes());
+        }
+        return thrownExceptions;
+    }
+}

--- a/src/jdiff/doc/FieldDoc.java
+++ b/src/jdiff/doc/FieldDoc.java
@@ -1,0 +1,11 @@
+package jdiff.doc;
+
+public interface FieldDoc extends ProgramElementDoc {
+    String name();
+
+    Type type();
+
+    boolean isTransient();
+
+    boolean isVolatile();
+}

--- a/src/jdiff/doc/FieldDocImpl.java
+++ b/src/jdiff/doc/FieldDocImpl.java
@@ -1,0 +1,36 @@
+package jdiff.doc;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.VariableElement;
+
+final class FieldDocImpl extends BaseProgramElementDoc implements FieldDoc {
+    private final VariableElement element;
+    private final Type type;
+
+    FieldDocImpl(DocEnvironment environment, Element element) {
+        super(environment, element);
+        this.element = (VariableElement) element;
+        this.type = environment.getType(this.element.asType());
+    }
+
+    @Override
+    public String name() {
+        return element.getSimpleName().toString();
+    }
+
+    @Override
+    public Type type() {
+        return type;
+    }
+
+    @Override
+    public boolean isTransient() {
+        return element.getModifiers().contains(Modifier.TRANSIENT);
+    }
+
+    @Override
+    public boolean isVolatile() {
+        return element.getModifiers().contains(Modifier.VOLATILE);
+    }
+}

--- a/src/jdiff/doc/MethodDoc.java
+++ b/src/jdiff/doc/MethodDoc.java
@@ -1,0 +1,17 @@
+package jdiff.doc;
+
+public interface MethodDoc extends ProgramElementDoc {
+    String name();
+
+    Type returnType();
+
+    Parameter[] parameters();
+
+    Type[] thrownExceptions();
+
+    boolean isAbstract();
+
+    boolean isNative();
+
+    boolean isSynchronized();
+}

--- a/src/jdiff/doc/MethodDocImpl.java
+++ b/src/jdiff/doc/MethodDocImpl.java
@@ -1,0 +1,43 @@
+package jdiff.doc;
+
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+
+final class MethodDocImpl extends ExecutableMemberDocImpl implements MethodDoc {
+    private final Type returnType;
+
+    MethodDocImpl(DocEnvironment environment, ExecutableElement element) {
+        super(environment, element);
+        this.returnType = environment.getType(element.getReturnType());
+    }
+
+    @Override
+    public Type returnType() {
+        return returnType;
+    }
+
+    @Override
+    public Parameter[] parameters() {
+        return super.parameters();
+    }
+
+    @Override
+    public Type[] thrownExceptions() {
+        return super.thrownExceptions();
+    }
+
+    @Override
+    public boolean isAbstract() {
+        return executableElement().getModifiers().contains(Modifier.ABSTRACT);
+    }
+
+    @Override
+    public boolean isNative() {
+        return executableElement().getModifiers().contains(Modifier.NATIVE);
+    }
+
+    @Override
+    public boolean isSynchronized() {
+        return executableElement().getModifiers().contains(Modifier.SYNCHRONIZED);
+    }
+}

--- a/src/jdiff/doc/PackageDoc.java
+++ b/src/jdiff/doc/PackageDoc.java
@@ -1,0 +1,16 @@
+package jdiff.doc;
+
+/**
+ * Represents documentation for a Java package.
+ */
+public interface PackageDoc extends Doc {
+    /**
+     * Returns the package name.
+     */
+    String name();
+
+    /**
+     * Returns all classes contained in the package that are part of the documentation set.
+     */
+    ClassDoc[] allClasses();
+}

--- a/src/jdiff/doc/PackageDocImpl.java
+++ b/src/jdiff/doc/PackageDocImpl.java
@@ -1,0 +1,39 @@
+package jdiff.doc;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.lang.model.element.PackageElement;
+
+final class PackageDocImpl extends BaseDoc implements PackageDoc {
+    private final PackageElement element;
+    private final String name;
+    private final Map<String, ClassDocImpl> classes = new LinkedHashMap<>();
+
+    PackageDocImpl(DocEnvironment environment, PackageElement element, String name) {
+        super(environment, element, name);
+        this.element = element;
+        this.name = name == null ? "anonymous" : name;
+    }
+
+    void addClass(ClassDocImpl classDoc) {
+        classes.putIfAbsent(classDoc.qualifiedTypeName(), classDoc);
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public ClassDoc[] allClasses() {
+        if (classes.isEmpty()) {
+            return new ClassDoc[0];
+        }
+        List<ClassDocImpl> list = new ArrayList<>(classes.values());
+        Collections.sort(list);
+        return list.toArray(new ClassDoc[0]);
+    }
+}

--- a/src/jdiff/doc/Parameter.java
+++ b/src/jdiff/doc/Parameter.java
@@ -1,0 +1,7 @@
+package jdiff.doc;
+
+public interface Parameter {
+    String name();
+
+    Type type();
+}

--- a/src/jdiff/doc/ParameterImpl.java
+++ b/src/jdiff/doc/ParameterImpl.java
@@ -1,0 +1,23 @@
+package jdiff.doc;
+
+import javax.lang.model.element.VariableElement;
+
+final class ParameterImpl implements Parameter {
+    private final String name;
+    private final Type type;
+
+    ParameterImpl(DocEnvironment environment, VariableElement element) {
+        this.name = element.getSimpleName().toString();
+        this.type = environment.getType(element.asType());
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public Type type() {
+        return type;
+    }
+}

--- a/src/jdiff/doc/ProgramElementDoc.java
+++ b/src/jdiff/doc/ProgramElementDoc.java
@@ -1,0 +1,18 @@
+package jdiff.doc;
+
+/**
+ * Common operations for documented program elements (types, fields, methods, etc.).
+ */
+public interface ProgramElementDoc extends Doc {
+    boolean isStatic();
+
+    boolean isFinal();
+
+    boolean isPublic();
+
+    boolean isProtected();
+
+    boolean isPackagePrivate();
+
+    boolean isPrivate();
+}

--- a/src/jdiff/doc/RootDoc.java
+++ b/src/jdiff/doc/RootDoc.java
@@ -1,0 +1,9 @@
+package jdiff.doc;
+
+public interface RootDoc {
+    PackageDoc[] specifiedPackages();
+
+    ClassDoc[] specifiedClasses();
+
+    PackageDoc packageNamed(String name);
+}

--- a/src/jdiff/doc/RootDocImpl.java
+++ b/src/jdiff/doc/RootDocImpl.java
@@ -1,0 +1,86 @@
+package jdiff.doc;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.TypeElement;
+import jdk.javadoc.doclet.DocletEnvironment;
+
+public final class RootDocImpl implements RootDoc {
+    private final DocEnvironment environment;
+    private final PackageDoc[] packages;
+    private final ClassDoc[] specifiedClasses;
+    private final Map<String, PackageDocImpl> packagesByName;
+
+    private RootDocImpl(DocEnvironment environment,
+                        PackageDoc[] packages,
+                        ClassDoc[] specifiedClasses,
+                        Map<String, PackageDocImpl> packagesByName) {
+        this.environment = environment;
+        this.packages = packages;
+        this.specifiedClasses = specifiedClasses;
+        this.packagesByName = packagesByName;
+    }
+
+    public static RootDocImpl create(DocletEnvironment environment) {
+        DocEnvironment docEnv = new DocEnvironment(environment);
+        Map<String, PackageDocImpl> packagesByName = new LinkedHashMap<>();
+        List<ClassDoc> specifiedClasses = new ArrayList<>();
+
+        // Register all included classes so that package data is available.
+        for (Element element : environment.getIncludedElements()) {
+            if (element instanceof TypeElement) {
+                ClassDocImpl classDoc = docEnv.getClassDoc((TypeElement) element);
+                packagesByName.put(classDoc.containingPackage().name(), (PackageDocImpl) classDoc.containingPackage());
+            } else if (element instanceof PackageElement) {
+                PackageDocImpl pkg = docEnv.getPackage((PackageElement) element);
+                packagesByName.put(pkg.name(), pkg);
+            }
+        }
+
+        for (Element element : environment.getSpecifiedElements()) {
+            if (element instanceof PackageElement) {
+                PackageDocImpl pkg = docEnv.getPackage((PackageElement) element);
+                packagesByName.put(pkg.name(), pkg);
+            } else if (element instanceof TypeElement) {
+                ClassDocImpl classDoc = docEnv.getClassDoc((TypeElement) element);
+                packagesByName.put(classDoc.containingPackage().name(), (PackageDocImpl) classDoc.containingPackage());
+                specifiedClasses.add(classDoc);
+            }
+        }
+
+        // Ensure at least the discovered packages are present.
+        for (PackageDocImpl pkg : docEnv.packages()) {
+            packagesByName.putIfAbsent(pkg.name(), pkg);
+        }
+
+        PackageDoc[] packages = packagesByName.values().toArray(new PackageDoc[0]);
+        ClassDoc[] classes = specifiedClasses.toArray(new ClassDoc[0]);
+        return new RootDocImpl(docEnv, packages, classes, packagesByName);
+    }
+
+    @Override
+    public PackageDoc[] specifiedPackages() {
+        return packages;
+    }
+
+    @Override
+    public ClassDoc[] specifiedClasses() {
+        return specifiedClasses;
+    }
+
+    @Override
+    public PackageDoc packageNamed(String name) {
+        PackageDocImpl pkg = packagesByName.get(name);
+        if (pkg == null) {
+            pkg = environment.getOrCreatePackageByName(name);
+            packagesByName.put(name, pkg);
+        }
+        return pkg;
+    }
+}

--- a/src/jdiff/doc/Tag.java
+++ b/src/jdiff/doc/Tag.java
@@ -1,0 +1,16 @@
+package jdiff.doc;
+
+/**
+ * Minimal representation of a Javadoc tag used by the JDiff doclet.
+ */
+public interface Tag {
+    /**
+     * Returns the tag name (without the leading '@').
+     */
+    String name();
+
+    /**
+     * Returns the tag body text.
+     */
+    String text();
+}

--- a/src/jdiff/doc/TagImpl.java
+++ b/src/jdiff/doc/TagImpl.java
@@ -1,0 +1,21 @@
+package jdiff.doc;
+
+final class TagImpl implements Tag {
+    private final String name;
+    private final String text;
+
+    TagImpl(String name, String text) {
+        this.name = name;
+        this.text = text == null ? "" : text.trim();
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public String text() {
+        return text;
+    }
+}

--- a/src/jdiff/doc/Type.java
+++ b/src/jdiff/doc/Type.java
@@ -1,0 +1,17 @@
+package jdiff.doc;
+
+/**
+ * Representation of a Java type used by the doclet model.
+ */
+public interface Type {
+    /**
+     * Returns the fully qualified name of the (erased) type.
+     */
+    String qualifiedTypeName();
+
+    /**
+     * Returns a display form of the type, potentially including generics information.
+     */
+    @Override
+    String toString();
+}

--- a/src/jdiff/doc/TypeImpl.java
+++ b/src/jdiff/doc/TypeImpl.java
@@ -1,0 +1,37 @@
+package jdiff.doc;
+
+import javax.lang.model.type.ArrayType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+
+final class TypeImpl implements Type {
+    private final DocEnvironment environment;
+    private final TypeMirror mirror;
+
+    TypeImpl(DocEnvironment environment, TypeMirror mirror) {
+        this.environment = environment;
+        this.mirror = mirror;
+    }
+
+    TypeMirror mirror() {
+        return mirror;
+    }
+
+    @Override
+    public String qualifiedTypeName() {
+        if (mirror.getKind().isPrimitive() || mirror.getKind() == TypeKind.VOID) {
+            return mirror.toString();
+        }
+        if (mirror instanceof ArrayType) {
+            ArrayType arrayType = (ArrayType) mirror;
+            return environment.getType(arrayType.getComponentType()).qualifiedTypeName() + "[]";
+        }
+        TypeMirror erasure = environment.types().erasure(mirror);
+        return erasure.toString();
+    }
+
+    @Override
+    public String toString() {
+        return mirror.toString();
+    }
+}


### PR DESCRIPTION
## Summary
- replace usage of the legacy com.sun.javadoc API with an internal doclet model so the code compiles on JDK 17+
- reimplement the JDiff doclet to use the modern jdk.javadoc.doclet interfaces and forward options through the new adapter
- refresh option handling and XML generation helpers to use the new doc model while keeping existing behaviour

## Testing
- `javac -d build/classes -cp lib/xerces.jar $(find src -name "*.java" ! -name "JDiffAntTask.java")`


------
https://chatgpt.com/codex/tasks/task_e_68cf86faa9c48332abf2606582c7ddfb