### PR TITLE
Port doclet generation to JDK 17 APIs

### DIFF
--- a/src/jdiff/APIDiff.java
+++ b/src/jdiff/APIDiff.java
@@ -1,7 +1,6 @@
 package jdiff;
 
 import java.util.*;
-import com.sun.javadoc.*;
 
 /**
  * The class contains the changes between two API objects; packages added,

--- a/src/jdiff/ClassDiff.java
+++ b/src/jdiff/ClassDiff.java
@@ -1,7 +1,6 @@
 package jdiff;
 
 import java.util.*;
-import com.sun.javadoc.*;
 
 /**
  * The changes between two classes.

--- a/src/jdiff/MemberDiff.java
+++ b/src/jdiff/MemberDiff.java
@@ -1,7 +1,6 @@
 package jdiff;
 
 import java.util.*;
-import com.sun.javadoc.*;
 
 /**
  * The changes between two class constructor, method or field members.

--- a/src/jdiff/PackageDiff.java
+++ b/src/jdiff/PackageDiff.java
@@ -1,7 +1,6 @@
 package jdiff;
 
 import java.util.*;
-import com.sun.javadoc.*;
 
 /**
  * Changes between two packages.


### PR DESCRIPTION
## Summary
- migrate RootDocToXML to the JDK 9+ doclet APIs, replacing remaining com.sun.javadoc usage and reworking modifier, documentation, and package handling
- capture the -sourcepath option for package documentation fallback when processing options
- drop the obsolete com.sun.javadoc import stubs from diff helper classes

## Testing
- javac -d build/classes -classpath lib/xerces.jar -sourcepath src $(find src/jdiff -name '*.java' ! -name 'JDiffAntTask.java')

------
https://chatgpt.com/codex/tasks/task_e_68cf9424accc8332a52c26db27f8691e